### PR TITLE
feat: add table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Supported methods:
 - `terminal.info(obj)`
 - `terminal.warn(obj)`
 - `terminal.error(obj)`
+- `terminal.table(obj)`
 - `terminal.assert(assertion, obj)`
 
 ## Examples

--- a/client.d.ts
+++ b/client.d.ts
@@ -1,11 +1,11 @@
 declare module 'virtual:terminal' {
-
   export const terminal: {
-    log: (obj: any) => void
-    warn: (obj: any) => void
+    assert: (assertion: boolean, obj: any) => void
     error: (obj: any) => void
     info: (obj: any) => void
-    assert: (assertion: boolean, obj: any) => void
+    log: (obj: any) => void
+    table: (obj: any) => void
+    warn: (obj: any) => void
   }
   export default terminal
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dev:js": "nr build:js --watch src",
     "lint": "eslint \"{src,test}/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
+    "test": "vitest",
     "prepublishOnly": "npm run build",
     "release": "bumpp --commit --push --tag && npm publish"
   },
@@ -66,6 +67,7 @@
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^17.0.5",
+    "@vitejs/plugin-vue": "^2.0.0",
     "bumpp": "^7.1.1",
     "eslint": "^8.5.0",
     "esno": "^0.13.0",
@@ -74,9 +76,9 @@
     "typescript": "^4.5.4",
     "unbuild": "^0.6.7",
     "unplugin-auto-import": "^0.5.5",
-    "@vitejs/plugin-vue": "^2.0.0",
-    "vue": "^3.2.25",
-    "vite": "^2.7.10"
+    "vite": "^2.7.10",
+    "vitest": "^0.2.0",
+    "vue": "^3.2.25"
   },
   "peerDependencies": {
     "vite": "^2.0.0"

--- a/playground/basic/main.ts
+++ b/playground/basic/main.ts
@@ -11,3 +11,5 @@ terminal.assert(true, 'Assertion pass')
 terminal.assert(false, 'Assertion fails')
 
 terminal.info('Some info from the app')
+
+terminal.table(['vite', 'plugin', 'terminal'])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ specifiers:
   unbuild: ^0.6.7
   unplugin-auto-import: ^0.5.5
   vite: ^2.7.10
+  vitest: ^0.2.0
   vue: ^3.2.25
 
 dependencies:
@@ -48,6 +49,7 @@ devDependencies:
   unbuild: 0.6.7
   unplugin-auto-import: 0.5.11_vite@2.7.13
   vite: 2.7.13
+  vitest: 0.2.0
   vue: 3.2.27
 
 packages:
@@ -529,6 +531,16 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /@types/chai-subset/1.3.3:
+    resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
+    dependencies:
+      '@types/chai': 4.3.0
+    dev: true
+
+  /@types/chai/4.3.0:
+    resolution: {integrity: sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==}
+    dev: true
+
   /@types/debug/4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
@@ -883,6 +895,10 @@ packages:
       es-abstract: 1.19.1
     dev: true
 
+  /assertion-error/1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: true
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -957,6 +973,18 @@ packages:
     resolution: {integrity: sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==}
     dev: true
 
+  /chai/4.3.4:
+    resolution: {integrity: sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.2
+      deep-eql: 3.0.1
+      get-func-name: 2.0.0
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
   /chalk/2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -977,6 +1005,10 @@ packages:
   /chalk/5.0.0:
     resolution: {integrity: sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
+  /check-error/1.0.2:
+    resolution: {integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=}
     dev: true
 
   /ci-info/3.3.0:
@@ -1085,6 +1117,13 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+
+  /deep-eql/3.0.1:
+    resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
 
   /deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2050,6 +2089,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /get-func-name/2.0.0:
+    resolution: {integrity: sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=}
+    dev: true
+
   /get-intrinsic/1.1.1:
     resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
     dependencies:
@@ -2825,6 +2868,10 @@ packages:
     resolution: {integrity: sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==}
     dev: true
 
+  /pathval/1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
@@ -3244,6 +3291,16 @@ packages:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
     dev: true
 
+  /tinypool/0.1.1:
+    resolution: {integrity: sha512-sW2fQZ2BRb/GX5v55NkHiTrbMLx0eX0xNpP+VGhOe2f7Oo04+LeClDyM19zCE/WCy7jJ8kzIJ0Ojrxj3UhN9Sg==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy/0.2.8:
+    resolution: {integrity: sha512-4VXqQzzh9gC5uOLk77cLr9R3wqJq07xJlgM9IUdCNJCet139r+046ETKbU1x7mGs7B0k7eopyH5U6yflbBXNyA==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
     engines: {node: '>=4'}
@@ -3461,6 +3518,38 @@ packages:
       rollup: 2.64.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vitest/0.2.0:
+    resolution: {integrity: sha512-+8c0UN/KKQe/ye0CCCqYuPbOEZl12Fhb5hVkCiL2DdBA4jOEgHDd35AZqdHVBXaAoTedS3MD5G/LhkOxCWB8pw==}
+    engines: {node: '>=14.14.0'}
+    hasBin: true
+    peerDependencies:
+      '@vitest/ui': '*'
+      c8: '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@vitest/ui':
+        optional: true
+      c8:
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.0
+      '@types/chai-subset': 1.3.3
+      chai: 4.3.4
+      local-pkg: 0.4.1
+      tinypool: 0.1.1
+      tinyspy: 0.2.8
+      vite: 2.7.13
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
     dev: true
 
   /vue-eslint-parser/8.0.1_eslint@8.7.0:

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,0 +1,85 @@
+import { gray, lightGray, lightMagenta } from 'kolorist'
+
+export default function table(obj: any, indent: number) {
+  const table = createTable(obj)
+  const maxWidth = process.stdout.columns - indent
+  return renderTable(table, maxWidth, indent)
+}
+
+export function createTable(obj: any) {
+  const keys = Object.keys(obj)
+  const shouldRenderValuesCol = keys.some(key => !isObj(obj[key])) || keys.length === 0
+  const shouldRenderKeyCols = keys.some(key => isObj(obj[key]))
+  const rows: string[][] = []
+  const allValueKeys: string[] = []
+  const headerRow = ['(index)']
+  if (shouldRenderKeyCols) {
+    allValueKeys.push(...new Set(keys.flatMap(key => isObj(obj[key]) ? Object.keys(obj[key]) : [])))
+    headerRow.push(...allValueKeys)
+  }
+  if (shouldRenderValuesCol) headerRow.push('Values')
+  rows.push(headerRow)
+  keys.forEach((key) => {
+    const value = obj[key]
+    const row = [key]
+    if (shouldRenderKeyCols) {
+      row.push(...allValueKeys.map(key => isObj(value) ? (key in value ? value[key] : '') : ''))
+      if (shouldRenderValuesCol) row.push(isObj(value) ? '' : value)
+    }
+    else {
+      row.push(value)
+    }
+    rows.push(row)
+  })
+  return rows
+}
+
+export function renderTable(rows: string[][], width: number, indent = 0) {
+  const table: string[] = []
+  const minCellWidth = 5
+  const maxCols = Math.floor((width - 1) / (minCellWidth + 1))
+  const rowsToRender = rows.map(row => row.slice(0, maxCols))
+  const nRows = rowsToRender.length
+  const nCols = rowsToRender[0].length
+  const cellWidth = Math.floor((width - (nCols + 1)) / nCols)
+  const isTruncated = nCols !== rows[0].length
+
+  function getCellWidth(index: number) {
+    return index === nCols - 1
+      ? cellWidth + (width - ((cellWidth * nCols) + nCols + 1))
+      : cellWidth
+  }
+  function renderRow(row: string[], chars: string) {
+    const start = chars[0]
+    const mid = chars[2]
+    const end = chars[4]
+    return `${gray(start)}${row.join(gray(mid))}${gray(isTruncated ? '…' : end)}`
+  }
+  function renderSeparator(chars: string) {
+    const line = chars[1]
+    const rows = Array.from({ length: nCols }).map((_, index) => gray(line.repeat(getCellWidth(index))))
+    return renderRow(rows, chars)
+  }
+  function renderCell(cell: string, width: number, color: (str: string | number) => string) {
+    let content: string
+    content = isObj(cell) ? JSON.stringify(cell) : `${cell}`
+    content = content.length > (width - 2) ? `${content.slice(0, width - 3)}…` : content
+    content = content.padEnd(width - 2, ' ')
+    return color(` ${content} `)
+  }
+
+  rowsToRender.forEach((row, index) => {
+    if (index === 0) table.push(renderSeparator('┏━┳━┓'))
+    const color = index === 0 ? lightGray : lightMagenta
+    const cells = row.map((cell, index) => renderCell(cell, getCellWidth(index), color))
+    table.push(renderRow(cells, index === 0 ? '┃ ┃ ┃' : '│ │ │'))
+    const chars = index === 0 && rowsToRender.length === 1 ? '┗━┻━┛' : index === 0 ? '┡━╇━┩' : index < nRows - 1 ? '├─┼─┤' : '└─┴─┘'
+    table.push(renderSeparator(chars))
+  })
+
+  return table.join(`\n${' '.repeat(indent)}`)
+}
+
+function isObj(obj: any) {
+  return typeof obj === 'object'
+}

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { createTable, renderTable } from '../src/table'
+
+describe('createTable', () => {
+  it('should handle empty values', () => {
+    const data: string[] = []
+    expect(createTable(data)).toEqual([
+      ['(index)', 'Values'],
+    ])
+  })
+
+  it('should handle plain values', () => {
+    const data = ['a', 'b']
+    expect(createTable(data)).toEqual([
+      ['(index)', 'Values'],
+      ['0', 'a'],
+      ['1', 'b'],
+    ])
+  })
+
+  it('should handle objects', () => {
+    const data = [
+      { a: 'One', b: 'Two' },
+      { a: 'Three', b: 'Four' },
+    ]
+    expect(createTable(data)).toEqual([
+      ['(index)', 'a', 'b'],
+      ['0', 'One', 'Two'],
+      ['1', 'Three', 'Four'],
+    ])
+  })
+
+  it('should handle arrays', () => {
+    const data = [
+      ['One', 'Two'],
+      ['Three', 'Four'],
+    ]
+    expect(createTable(data)).toEqual([
+      ['(index)', '0', '1'],
+      ['0', 'One', 'Two'],
+      ['1', 'Three', 'Four'],
+    ])
+  })
+
+  it('should handle objects with different properties', () => {
+    const data = [
+      { a: 'One', b: 'Two' },
+      { a: 'Three', c: 'Four' },
+    ]
+    expect(createTable(data)).toEqual([
+      ['(index)', 'a', 'b', 'c'],
+      ['0', 'One', 'Two', ''],
+      ['1', 'Three', '', 'Four'],
+    ])
+  })
+
+  it('should handle plain values mixed with objects', () => {
+    const data = [
+      { a: 'One', b: 'Two' },
+      'Plain string',
+    ]
+    expect(createTable(data)).toEqual([
+      ['(index)', 'a', 'b', 'Values'],
+      ['0', 'One', 'Two', ''],
+      ['1', '', '', 'Plain string'],
+    ])
+  })
+
+  it('should handle plain values mixed with arrays', () => {
+    const data = [
+      ['a', 'b'],
+      'Plain string',
+    ]
+    expect(createTable(data)).toEqual([
+      ['(index)', '0', '1', 'Values'],
+      ['0', 'a', 'b', ''],
+      ['1', '', '', 'Plain string'],
+    ])
+  })
+
+  it('should handle plain values mixed with objects and arrays', () => {
+    const data = [
+      { a: 'One', b: 'Two' },
+      ['a', 'b'],
+      'Plain string',
+    ]
+    expect(createTable(data)).toEqual([
+      ['(index)', 'a', 'b', '0', '1', 'Values'],
+      ['0', 'One', 'Two', '', '', ''],
+      ['1', '', '', 'a', 'b', ''],
+      ['2', '', '', '', '', 'Plain string'],
+    ])
+  })
+})
+
+describe('renderTable', () => {
+  it ('should handle empty tables', () => {
+    const data: string[] = []
+    expect(renderTable(createTable(data), 40)).toBe(`
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃ (index)          ┃ Values            ┃
+┗━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━┛
+`.trim())
+  })
+
+  it ('should serialize nested arrays', () => {
+    const data = [[['a', 'b']]]
+    expect(renderTable(createTable(data), 40)).toBe(`
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃ (index)          ┃ 0                 ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+│ 0                │ ["a","b"]         │
+└──────────────────┴───────────────────┘
+`.trim())
+  })
+
+  it ('should serialize nested objects', () => {
+    const data = [[{ a: 'One' }]]
+    expect(renderTable(createTable(data), 40)).toBe(`
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃ (index)          ┃ 0                 ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+│ 0                │ {"a":"One"}       │
+└──────────────────┴───────────────────┘
+`.trim())
+  })
+
+  it ('should truncate cell content', () => {
+    const data = ['This string is too long to fit in the cell']
+    expect(renderTable(createTable(data), 40)).toBe(`
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃ (index)          ┃ Values            ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+│ 0                │ This string is t… │
+└──────────────────┴───────────────────┘
+`.trim())
+  })
+
+  it ('should truncate amount of columns', () => {
+    const data = [{ a: 'One', b: 'Two', c: 'Three', d: 'Four', e: 'Five', f: 'Six' }]
+    expect(renderTable(createTable(data), 40)).toBe(`
+┏━━━━━┳━━━━━┳━━━━━┳━━━━━┳━━━━━┳━━━━━━━━…
+┃ (i… ┃ a   ┃ b   ┃ c   ┃ d   ┃ e      …
+┡━━━━━╇━━━━━╇━━━━━╇━━━━━╇━━━━━╇━━━━━━━━…
+│ 0   │ One │ Two │ Th… │ Fo… │ Five   …
+└─────┴─────┴─────┴─────┴─────┴────────…
+`.trim())
+  })
+
+  it ('should indent', () => {
+    const data = ['a']
+    expect(`» ${renderTable(createTable(data), 38, 2)}`).toBe(`
+» ┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+  ┃ (index)         ┃ Values           ┃
+  ┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
+  │ 0               │ a                │
+  └─────────────────┴──────────────────┘
+`.trim())
+  })
+})


### PR DESCRIPTION
Thanks for this plugin Patak!

This PR adds support for `terminal.table()`.
It also adds some tests (via vitest) for the table rendering.

Example:
```js
terminal.table([0, 1, 2])
terminal.table([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]])
terminal.table({ a: 'one', b: 'two' })
terminal.table({ a: 'one', b: [[1, 2, 3], 'test'], c: 'three', d: [{ a: 'a', b: 'b' }, 'test'] })
terminal.table({ a: ['one', 'two'], b: ['three', 'four'], c: ['five', 'six'] })
terminal.table({ a: ['one', 'two', 'three'], b: ['one', 'two'], c: ['one', 'two', 'three', 'four', 'five'], d: 'Plain string' })
terminal.table({ a: { one: 'one', two: 'two', three: 'three' }, b: { one: 'one', two: 'two' } })
terminal.table({ a: { one: 'one', two: 'two', three: 'three' }, b: { one: 'one', two: 'two' }, c: 'Plain string' })
```

<img width="570" alt="Screenshot 2022-01-23 at 20 31 37" src="https://user-images.githubusercontent.com/12999787/150694897-4dae6a03-140e-4391-9499-197c53780808.png">


