### PR TITLE
feat: Add multiple args log

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Supported methods:
 - `terminal.info(obj1 [, obj2, ..., objN])`
 - `terminal.warn(obj1 [, obj2, ..., objN])`
 - `terminal.error(obj1 [, obj2, ..., objN])`
+- `terminal.assert(assertion, obj1 [, obj2, ..., objN])`
 - `terminal.table(obj)`
-- `terminal.assert(assertion, obj)`
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ The terminal log calls will be removed when building the app.
 
 Supported methods:
 
-- `terminal.log(obj)`
+- `terminal.log(obj1 [, obj2, ..., objN])`
+- `terminal.info(obj1 [, obj2, ..., objN])`
+- `terminal.warn(obj1 [, obj2, ..., objN])`
+- `terminal.error(obj1 [, obj2, ..., objN])`
 - `terminal.log(obj1, obj2, ...)`
-- `terminal.info(obj)`
-- `terminal.warn(obj)`
-- `terminal.error(obj)`
 - `terminal.table(obj)`
 - `terminal.assert(assertion, obj)`
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ The terminal log calls will be removed when building the app.
 ## API
 
 Supported methods:
+
 - `terminal.log(obj)`
+- `terminal.log(obj1, obj2, ...)`
 - `terminal.info(obj)`
 - `terminal.warn(obj)`
 - `terminal.error(obj)`

--- a/README.md
+++ b/README.md
@@ -42,12 +42,10 @@ The terminal log calls will be removed when building the app.
 ## API
 
 Supported methods:
-
 - `terminal.log(obj1 [, obj2, ..., objN])`
 - `terminal.info(obj1 [, obj2, ..., objN])`
 - `terminal.warn(obj1 [, obj2, ..., objN])`
 - `terminal.error(obj1 [, obj2, ..., objN])`
-- `terminal.log(obj1, obj2, ...)`
 - `terminal.table(obj)`
 - `terminal.assert(assertion, obj)`
 

--- a/client.d.ts
+++ b/client.d.ts
@@ -3,7 +3,7 @@ declare module 'virtual:terminal' {
     assert: (assertion: boolean, obj: any) => void
     error: (obj: any) => void
     info: (obj: any) => void
-    log: (obj: any) => void
+    log: (...obj: any[]) => void
     table: (obj: any) => void
     warn: (obj: any) => void
   }

--- a/client.d.ts
+++ b/client.d.ts
@@ -1,11 +1,11 @@
 declare module 'virtual:terminal' {
   export const terminal: {
     assert: (assertion: boolean, obj: any) => void
-    error: (obj: any) => void
-    info: (obj: any) => void
+    error: (...obj: any[]) => void
+    info: (...obj: any[]) => void
     log: (...obj: any[]) => void
     table: (obj: any) => void
-    warn: (obj: any) => void
+    warn: (...obj: any[]) => void
   }
   export default terminal
 }

--- a/playground/basic/main.ts
+++ b/playground/basic/main.ts
@@ -6,7 +6,7 @@ terminal.log('Hey terminal! A message from the browser')
 const json = { foo: 'bar' }
 
 terminal.log({ json })
-terminal.log('First arg', 'Second arg')
+terminal.log('First arg', { second: 'arg' })
 terminal.assert(true, 'Assertion pass')
 terminal.assert(false, 'Assertion fails')
 

--- a/playground/basic/main.ts
+++ b/playground/basic/main.ts
@@ -6,7 +6,7 @@ terminal.log('Hey terminal! A message from the browser')
 const json = { foo: 'bar' }
 
 terminal.log({ json })
-
+terminal.log('Firest arg', 'Second arg')
 terminal.assert(true, 'Assertion pass')
 terminal.assert(false, 'Assertion fails')
 

--- a/playground/basic/main.ts
+++ b/playground/basic/main.ts
@@ -6,7 +6,7 @@ terminal.log('Hey terminal! A message from the browser')
 const json = { foo: 'bar' }
 
 terminal.log({ json })
-terminal.log('Firest arg', 'Second arg')
+terminal.log('First arg', 'Second arg')
 terminal.assert(true, 'Assertion pass')
 terminal.assert(false, 'Assertion fails')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,17 +104,24 @@ function generateVirtualModuleCode() {
 export default terminal
 `
 }
+
 function createTerminal() {
+  function stringify(obj: any) {
+    return typeof obj === 'object' ? `${JSON.stringify(obj)}` : obj.toString()
+  }
+  function prettyPrint(obj: any) {
+    return JSON.stringify(obj, null, 2)
+  }
   function send(type: string, ...objs: any[]) {
     switch (type) {
       case 'table': {
-        const message = JSON.stringify(objs[0], null, 2)
+        const message = prettyPrint(objs[0])
         fetch(`/__terminal/${type}?${encodeURI(message)}`)
         break
       }
       default: {
-        const obj = objs.length > 1 ? objs.join(' ') : objs[0]
-        const message = typeof obj === 'object' ? `${JSON.stringify(obj, null, 2)}` : obj.toString()
+        const obj = objs.length > 1 ? objs.map(stringify).join(' ') : objs[0]
+        const message = typeof obj === 'object' ? `${prettyPrint(obj)}` : obj.toString()
         fetch(`/__terminal/${type}?${encodeURI(message)}`)
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,30 +105,27 @@ export default terminal
 `
 }
 function createTerminal() {
-  function send(type: string, ...obj: any[]) {
+  function send(type: string, ...objs: any[]) {
     switch (type) {
       case 'table': {
-        const message = JSON.stringify(obj[0], null, 2)
+        const message = JSON.stringify(objs[0], null, 2)
         fetch(`/__terminal/${type}?${encodeURI(message)}`)
         break
       }
       default: {
-        let message = ''
-        if (obj.length > 1)
-          message = obj.join(', ')
-        else if (obj.length === 1)
-          message = typeof obj[0] === 'object' ? `${JSON.stringify(obj[0], null, 2)}` : obj[0].toString()
+        const obj = objs.length > 1 ? objs.join(' ') : objs[0]
+        const message = typeof obj === 'object' ? `${JSON.stringify(obj, null, 2)}` : obj.toString()
         fetch(`/__terminal/${type}?${encodeURI(message)}`)
       }
     }
   }
   return {
-    assert: (assertion: boolean, obj: any) => assertion && send('assert', obj),
-    error: (...obj: any[]) => send('error', ...obj),
-    info: (...obj: any[]) => send('info', ...obj),
-    log: (...obj: any[]) => send('log', ...obj),
+    log: (...objs: any[]) => send('log', ...objs),
+    info: (...objs: any[]) => send('info', ...objs),
+    warn: (...objs: any[]) => send('warn', ...objs),
+    error: (...objs: any[]) => send('error', ...objs),
+    assert: (assertion: boolean, ...objs: any[]) => assertion && send('assert', ...objs),
     table: (obj: any) => send('table', obj),
-    warn: (...obj: any[]) => send('warn', ...obj),
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,13 @@ function pluginTerminal(options: Options = {}) {
                 config.logger.info(`» ${table(obj, indent)}`)
                 break
               }
+              case 'log': {
+                let obj = JSON.parse(message)
+                if (Array.isArray(obj))
+                  obj = obj.length === 1 ? JSON.stringify(obj[0], null, 2) : obj.toString()
+                config.logger.info(colors.log(`» ${obj}`))
+                break
+              }
               default: {
                 const color = colors[method]
                 config.logger.info(color(`» ${message}`))
@@ -113,7 +120,7 @@ function createTerminal() {
     assert: (assertion: boolean, obj: any) => assertion && send('assert', obj),
     error: (obj: any) => send('error', obj),
     info: (obj: any) => send('info', obj),
-    log: (obj: any) => send('log', obj),
+    log: (...obj: any[]) => send('log', obj),
     table: (obj: any) => send('table', obj),
     warn: (obj: any) => send('warn', obj),
   }


### PR DESCRIPTION
This PR adds support for terminal.log(arg1,arg2,...).

Example:

<img width="321" alt="Screen Shot 2022-01-27 at 14 19 04" src="https://user-images.githubusercontent.com/35465776/151410134-a21964ee-2869-47d0-b449-00c750a1535f.png">

<img width="189" alt="Screen Shot 2022-01-27 at 14 19 45" src="https://user-images.githubusercontent.com/35465776/151410263-bad82e21-97b0-4ead-a6e1-f945ab3e8e0b.png">

