### PR TITLE
feat: terminal.group support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Supported methods:
 - `terminal.warn(obj1 [, obj2, ..., objN])`
 - `terminal.error(obj1 [, obj2, ..., objN])`
 - `terminal.assert(assertion, obj1 [, obj2, ..., objN])`
+- `terminal.group()`
+- `terminal.groupEnd()`
 - `terminal.table(obj)`
 
 

--- a/client.d.ts
+++ b/client.d.ts
@@ -6,6 +6,8 @@ declare module 'virtual:terminal' {
     log: (...obj: any[]) => void
     table: (obj: any) => void
     warn: (...obj: any[]) => void
+    group: () => void
+    groupEnd: () => void
   }
   export default terminal
 }

--- a/playground/basic/main.ts
+++ b/playground/basic/main.ts
@@ -5,6 +5,10 @@ terminal.log('Hey terminal! A message from the browser')
 
 const json = { foo: 'bar' }
 
+terminal.group()
+terminal.log('Grouped log')
+terminal.groupEnd()
+
 terminal.log({ json })
 terminal.log('First arg', { second: 'arg' })
 terminal.assert(true, 'Assertion pass')

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,22 +68,23 @@ function pluginTerminal(options: Options = {}) {
         const { pathname, search } = parseURL(req.url)
         const searchParams = new URLSearchParams(search.slice(1))
         const messageURL = searchParams.get('m') ?? ''
-        const time = searchParams.get('t') ?? ''
-        const queueOrder = searchParams.get('q') ?? ''
+        const time = searchParams.get('t') ?? '0'
+        const queueOrder = searchParams.get('q') ?? '0'
         const message = decodeURI(messageURL).split('\n').join('\n  ')
         if (pathname[0] === '/') {
           const method = pathname.slice(1) as Method
           if (methods.includes(method)) {
             switch (method) {
               case 'table': {
+                const groupLevel = searchParams.get('gl') ?? '0'
                 const obj = JSON.parse(message)
-                const indent = 2
+                const indent = 2 * (parseInt(groupLevel) + 1)
                 dispatchLog({ priority: parseInt(time), queueOrder: parseInt(queueOrder), dispatchFunction: () => config.logger.info(`» ${table(obj, indent)}`) })
                 break
               }
               default: {
                 const color = colors[method]
-                dispatchLog({ priority: parseInt(time), queueOrder: parseInt(queueOrder), dispatchFunction: () => config.logger.info(color(`» ${method === 'assert' ? 'Assertion failed: ' : ''}${message}`)) })
+                dispatchLog({ priority: parseInt(time), queueOrder: parseInt(queueOrder), dispatchFunction: () => config.logger.info(color(`» ${message}`)) })
                 break
               }
             }
@@ -111,22 +112,40 @@ export default terminal
 }
 function createTerminal() {
   let queueOrder = 0
+  let groupLevel = 0
   function stringify(obj: any) {
     return typeof obj === 'object' ? `${JSON.stringify(obj)}` : obj.toString()
   }
   function prettyPrint(obj: any) {
     return JSON.stringify(obj, null, 2)
   }
+  const groupText = (text: string) => {
+    if (groupLevel !== 0)
+      return `${'  '.repeat(groupLevel)}${text.split('\n').join(`\n${'  '.repeat(groupLevel)}`)}`
+    else
+      return text
+  }
   function send(type: string, ...objs: any[]) {
     switch (type) {
       case 'table': {
         const message = prettyPrint(objs[0])
-        fetch(`/__terminal/${type}?m=${encodeURI(message)}&t=${Date.now()}&q=${queueOrder++}`)
+        fetch(`/__terminal/${type}?m=${encodeURI(message)}&t=${Date.now()}&q=${queueOrder++}&gl=${groupLevel}`)
+        break
+      }
+      case 'group': {
+        groupLevel++
+        break
+      }
+      case 'groupEnd': {
+        groupLevel = groupLevel === 0 ? groupLevel : --groupLevel
         break
       }
       default: {
         const obj = objs.length > 1 ? objs.map(stringify).join(' ') : objs[0]
-        const message = typeof obj === 'object' ? `${prettyPrint(obj)}` : obj.toString()
+        let message = typeof obj === 'object' ? `${prettyPrint(obj)}` : obj.toString()
+        const prefix = type === 'assert' ? 'Assertion failed: ' : ''
+        message = prefix + message
+        message = groupText(message)
         fetch(`/__terminal/${type}?m=${encodeURI(message)}&t=${Date.now()}&q=${queueOrder++}`)
       }
     }
@@ -138,6 +157,8 @@ function createTerminal() {
     error: (...objs: any[]) => send('error', ...objs),
     assert: (assertion: boolean, ...objs: any[]) => !assertion && send('assert', ...objs),
     table: (obj: any) => send('table', obj),
+    group: () => send('group'),
+    groupEnd: () => send('groupEnd'),
   }
 }
 

--- a/src/logQueue.ts
+++ b/src/logQueue.ts
@@ -17,9 +17,8 @@ const dispatchLog = ({ priority, queueOrder, dispatchFunction }: QueuedLog) => {
   })
   if (priority < lastDispatched) {
     setTimeout(() => {
-      while (queue[0] && queue[0].priority < lastDispatched) {
+      while (queue[0] && queue[0].priority < lastDispatched)
         queue.shift()!.dispatchFunction()
-      }
     }, 50)
   }
   lastDispatched++

--- a/src/table.ts
+++ b/src/table.ts
@@ -77,7 +77,7 @@ export function renderTable(rows: string[][], width: number, indent = 0) {
     table.push(renderSeparator(chars))
   })
 
-  return table.join(`\n${' '.repeat(indent)}`)
+  return `${' '.repeat(indent - 2)}${table.join(`\n${' '.repeat(indent)}`)}`
 }
 
 function isObj(obj: any) {


### PR DESCRIPTION
This PR adds group and groupEnd functionality to the plugin. The message is formatted on the browser, that's why we don't need to send the window GUID or sthing similar.

Small fix on queueLog file after ! addition.