### PR TITLE
feat: auto open playgrounds on start

### DIFF
--- a/playground/autoimport/vite.config.ts
+++ b/playground/autoimport/vite.config.ts
@@ -22,4 +22,7 @@ export default defineConfig({
   preview: {
     port: 4173,
   },
+  server: {
+    open: true,
+  },
 })

--- a/playground/basic/vite.config.ts
+++ b/playground/basic/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
   preview: {
     port: 4173,
   },
+  server: {
+    open: true,
+  },
 })

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
     vue(),
     terminal(),
   ],
+  server: {
+    open: true,
+  },
 })


### PR DESCRIPTION
This PR allows apps to open the browser when user runs a run command.
It also works with  "play:basic", "play:autoimport" and "play:vue" commands