### PR TITLE
feat: console timers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Supported methods:
 - `terminal.group()`
 - `terminal.groupEnd()`
 - `terminal.table(obj)`
+- `terminal.time(timerId)`
+- `terminal.timeLog(timerId)`
+- `terminal.timeEnd(timerId)`
 
 
 ## Examples

--- a/client.d.ts
+++ b/client.d.ts
@@ -8,6 +8,9 @@ declare module 'virtual:terminal' {
     warn: (...obj: any[]) => void
     group: () => void
     groupEnd: () => void
+    time: (obj: string) => void
+    timeLog: (obj: string) => void
+    timeEnd: (obj: string) => void
   }
   export default terminal
 }

--- a/playground/basic/main.ts
+++ b/playground/basic/main.ts
@@ -10,6 +10,8 @@ terminal.log('Grouped log')
 terminal.groupEnd()
 
 terminal.log({ json })
+terminal.time('firstTimer')
+terminal.timeLog('notimer')
 terminal.log('First arg', { second: 'arg' })
 terminal.assert(true, 'Assertion pass')
 terminal.assert(false, 'Assertion fails')
@@ -17,3 +19,9 @@ terminal.assert(false, 'Assertion fails')
 terminal.info('Some info from the app')
 
 terminal.table(['vite', 'plugin', 'terminal'])
+
+setTimeout(() => {
+  terminal.timeLog('firstTimer')
+  terminal.timeEnd('firstTimer')
+  terminal.timeLog('firstTimer')
+}, 1000)

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,6 @@ function generateVirtualModuleCode() {
 export default terminal
 `
 }
-
 function createTerminal() {
   let queueOrder = 0
   let groupLevel = 0


### PR DESCRIPTION
This PR allow users to use terminal.time, terminal.timeLog and timer.logEnd.

Example output for basic project:
<img width="1018" alt="Screen Shot 2022-02-02 at 21 31 52" src="https://user-images.githubusercontent.com/35465776/152261000-8e4538de-53f8-4b4d-a6b5-4581c6b0c117.png">

Note: this cannot be modularized and all logic is inside createTerminal function because it can't use imported modules since it is stringified.
