### PR TITLE
Add typings information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ terminal.log('Hey terminal! A message from the browser')
 
 The terminal log calls will be removed when building the app.
 
+## Types
+
+There are two ways of telling typescript about the types of the virtual import:
+
+- In your `global.d.ts` file add the following line:
+  ```ts
+  /// <reference types="vite-plugin-terminal/client" />
+  ```
+
+- In your `tsconfig.json` add the following to your `compilerOptions.types` array:
+
+  ```json
+  {
+    // ...
+    "compilerOptions": {
+      // ...
+      "types": [
+        "vite-plugin-terminal/client"
+      ],
+    },
+  }
+  ```
+
+
 ## API
 
 Supported methods:


### PR DESCRIPTION
Was playing around with this with @fractalHQ and we had some issues figuring out how to get the types for the virtual import, this pr adds a section to the readme about the two methods of doing this