### PR TITLE
Fix undefined values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ function createTerminal() {
   }
 
   function stringify(obj: any) {
-    return ['object', 'undefined'].includes(typeof obj) ? `${JSON.stringify(obj)}` : obj.toString()
+    return JSON.stringify(obj)
   }
 
   function prettyPrint(obj: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ function createTerminal() {
   }
 
   function stringify(obj: any) {
-    return typeof obj === 'object' ? `${JSON.stringify(obj)}` : obj.toString()
+    return ['object', 'undefined'].includes(typeof obj) ? `${JSON.stringify(obj)}` : obj.toString()
   }
 
   function prettyPrint(obj: any) {


### PR DESCRIPTION
terminal.log('Hello ', undefined)

will crash the plugin with `property toString() does not exist in undefined`
