### PR TITLE
feat: add vite 3 and console.debug() support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import readline from 'readline'
-import { lightGray, lightMagenta, lightRed, lightYellow } from 'kolorist'
+import { lightBlue, lightGray, lightMagenta, lightRed, lightYellow } from 'kolorist'
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import { parseURL } from 'ufo'
 import rollupPluginStrip from '@rollup/plugin-strip'

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ interface Terminal {
   error: (...obj: any[]) => void
   info: (...obj: any[]) => void
   log: (...obj: any[]) => void
+  debug: (...obj: any[]) => void
   table: (obj: any) => void
   warn: (...obj: any[]) => void
   group: () => void
@@ -73,12 +74,13 @@ interface Terminal {
   profileEnd: (...args: any[]) => void
 }
 
-const methods = ['assert', 'error', 'info', 'log', 'table', 'warn', 'clear'] as const
+const methods = ['assert', 'debug', 'error', 'info', 'log', 'table', 'warn', 'clear'] as const
 type Method = typeof methods[number]
 
 const colors = {
   log: lightMagenta,
   info: lightGray,
+  debug: lightBlue,
   warn: lightYellow,
   error: lightRed,
   assert: lightRed,
@@ -235,6 +237,7 @@ function createTerminal() {
   const terminal = {
     log(...objs: any[]) { send('log', stringifyObjs(objs)) },
     info(...objs: any[]) { send('info', stringifyObjs(objs)) },
+    debug(...objs: any[]) { send('debug', stringifyObjs(objs)) },
     warn(...objs: any[]) { send('warn', stringifyObjs(objs)) },
     error(...objs: any[]) { send('error', stringifyObjs(objs)) },
     assert(assertion: boolean, ...objs: any[]) {


### PR DESCRIPTION
console.debug should be available. I've found people using it in sandboxes, causing terminal to throw stack traces.

![Screenshot 2022-07-21 02 59 43](https://user-images.githubusercontent.com/876076/180161901-e4db660d-8e38-43f1-9295-a68de9d4e246.png)

Sandbox with PR applied: https://stackblitz.com/edit/vueschool-pinia-the-enjoyable-vue-store-qt7x5r?file=vite-plugin-terminal%2Fsrc%2Findex.ts

After PR screenshots:
![Screenshot 2022-07-21 03 21 38](https://user-images.githubusercontent.com/876076/180166732-afe13b63-01a0-455b-aad7-3ec58f08fcdc.png)
![Screenshot 2022-07-21 03 21 23](https://user-images.githubusercontent.com/876076/180166735-607cdd43-8e25-4b72-a331-73f8540dd264.png)
