### PR TITLE
fix: Vite Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "vue": "^3.2.25"
   },
   "peerDependencies": {
-    "vite": "^2.0.0"
+    "vite": "^2.0.0||^3.0.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
Vite 3 support was added in #18 (v1.0.2) but the peer dependency for `vite` wasn't updated so there are warnings when installing:

![image](https://user-images.githubusercontent.com/47755378/197063333-3a927ebd-23ba-4f89-b9c3-a642878a8d1c.png)
