### PR TITLE
fix: add encodeURI to decodeURI param

### DIFF
--- a/playground/basic/main.ts
+++ b/playground/basic/main.ts
@@ -33,3 +33,5 @@ setTimeout(() => {
   terminal.timeLog('timer', 'message with a timer')
   terminal.timeEnd('timer')
 }, 1000)
+
+terminal.log('Properly encoded message %')

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,8 +136,7 @@ function pluginTerminal(options: Options = {}) {
       server.middlewares.use('/__terminal', (req, res) => {
         const { pathname, search } = parseURL(req.url)
         const searchParams = new URLSearchParams(search.slice(1))
-
-        const message = decodeURI(encodeURI(searchParams.get('m') ?? '').split('\n').join('\n  '))
+        const message = (searchParams.get('m') ?? '').split('\n').join('\n  ')
         const time = parseInt(searchParams.get('t') ?? '0')
         const count = parseInt(searchParams.get('c') ?? '0')
         const groupLevel = parseInt(searchParams.get('g') ?? '0')

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ function pluginTerminal(options: Options = {}) {
         const { pathname, search } = parseURL(req.url)
         const searchParams = new URLSearchParams(search.slice(1))
 
-        const message = decodeURI(searchParams.get('m') ?? '').split('\n').join('\n  ')
+        const message = decodeURI(encodeURI(searchParams.get('m') ?? '').split('\n').join('\n  '))
         const time = parseInt(searchParams.get('t') ?? '0')
         const count = parseInt(searchParams.get('c') ?? '0')
         const groupLevel = parseInt(searchParams.get('g') ?? '0')


### PR DESCRIPTION
"decodeURI" method can't handle some special characters like '%', resulting in a "URI malformed" error.
